### PR TITLE
Make it compiling without via-ir

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,8 +3,8 @@ src = "src"
 out = "out"
 libs = ["lib"]
 fs_permissions = [{ access = "read", path = "./"}]
-solc = "0.8.21"
+solc = "0.8.20"
 optimizer_runs=999999
-via_ir=true
+#via_ir=true
 
 # See more config options https://book.getfoundry.sh/reference/config/

--- a/src/P256.sol
+++ b/src/P256.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 /**
  * Helper library for external contracts to verify P256 signatures.

--- a/src/WebAuthn.sol
+++ b/src/WebAuthn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 import "./utils/Base64URL.sol";
 import "./P256.sol";

--- a/src/utils/Base64URL.sol
+++ b/src/utils/Base64URL.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 import "openzeppelin-contracts/contracts/utils/Base64.sol";
 

--- a/test/GasBenchmark.t.sol
+++ b/test/GasBenchmark.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {stdJson} from "forge-std/StdJson.sol";

--- a/test/P256.t.sol
+++ b/test/P256.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {stdJson} from "forge-std/StdJson.sol";

--- a/test/P256Verifier.t.sol
+++ b/test/P256Verifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {stdJson} from "forge-std/StdJson.sol";

--- a/test/WebAuthn.t.sol
+++ b/test/WebAuthn.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {stdJson} from "forge-std/StdJson.sol";

--- a/test/utils/Base64URL.t.sol
+++ b/test/utils/Base64URL.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity 0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {stdJson} from "forge-std/StdJson.sol";


### PR DESCRIPTION
Making it compiling with 0.8.20 compiler and without the via-ir flag. This way we can use this in our mono-repo as a submodule.

Currently the gas related tests are failing, but the functional ones are working - as expected.

<img width="643" alt="kép" src="https://github.com/taikoxyz/p256-verifier/assets/51912515/7cbaa904-b07e-40a8-a6f9-cc8faf61f1ab">
